### PR TITLE
Introduce lang flag instead of direct language name as flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 crontalk
+go.sum

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ And the result will be ```Every Day At 12:06PM```.
 Also **CronTalk** supports multiple languages (english & bangla for now with english being the default). So try,
 
 ```
-$ crontalk translate "6 12 * * *" --bangla
+$ crontalk translate "6 12 * * *" --lang=bangla
 
 ```
 And you will get something like ```প্রতিদিন সময় ১২:০৬PM```

--- a/helper/consts.go
+++ b/helper/consts.go
@@ -1,0 +1,6 @@
+package helper
+
+// general constants used around the app
+const (
+	LanguageEnglish = "english"
+)

--- a/helper/errors.go
+++ b/helper/errors.go
@@ -1,0 +1,6 @@
+package helper
+
+// the error messages
+const (
+	ErrInvalidLangValue = "invalid value provided for the --language flag"
+)

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -12,8 +12,6 @@ import (
 	"github.com/Anondo/crontalk/helper"
 
 	translator "github.com/Anondo/crontalk/translator"
-
-	"github.com/spf13/viper"
 )
 
 func translateHandler(w http.ResponseWriter, r *http.Request) {
@@ -54,9 +52,9 @@ func translateHandler(w http.ResponseWriter, r *http.Request) {
 	output := translator.GetTranslatedStr()
 	output = helper.TrimExtraSpaces(output)
 
-	if viper.GetBool("bangla") {
-		helper.ChangeDigitLanguage(&output, "bangla") //changing the english digits to bangla
-	}
+	// if viper.GetBool("bangla") {
+	// 	helper.ChangeDigitLanguage(&output, "bangla") //changing the english digits to bangla
+	// }
 
 	output = helper.AddOrdinals(output)
 

--- a/translator/translator.go
+++ b/translator/translator.go
@@ -1,15 +1,11 @@
 package translator
 
 import (
-	"github.com/Anondo/crontalk/helper"
 	"strings"
 
-	"github.com/spf13/viper"
-)
+	"github.com/Anondo/crontalk/helper"
 
-const (
-	english = "english"
-	bangla  = "bangla"
+	"github.com/spf13/viper"
 )
 
 var (
@@ -17,14 +13,11 @@ var (
 	months    = map[int]string{}
 	baseIndex int
 	configStr = ""
-	language  = english
 )
 
 // Init initializes the translator
 func Init() {
-	if viper.GetBool(bangla) {
-		language = bangla
-	}
+	language := viper.GetString("lang")
 	configStr = "language." + language + "." //the config index to parse the config yaml file from viper
 
 	weeks = map[int]string{


### PR DESCRIPTION
Instead of having flags with the name of individual language, introduced a new flag called **lang** whose value would be the potential languages(``--lang=bangla``). As a result, any language can be plugged into the system by just adding it in the config file without changing the code.